### PR TITLE
fixed cookie encoding

### DIFF
--- a/tiddlyweb/web/extractors/simple_cookie.py
+++ b/tiddlyweb/web/extractors/simple_cookie.py
@@ -33,7 +33,7 @@ class Extractor(ExtractorInterface):
             LOGGER.debug('simple_cookie looking at cookie string: %s',
                     user_cookie)
             cookie = Cookie.SimpleCookie()
-            cookie.load(user_cookie)
+            cookie.load(user_cookie.encode('utf-8'))
             cookie_value = cookie['tiddlyweb_user'].value
             secret = environ['tiddlyweb.config']['secret']
             usersign, cookie_secret = cookie_value.rsplit(':', 1)


### PR DESCRIPTION
prompted by BFW:
https://travis-ci.org/FND/tiddlywebplugins.bfw/builds/13645282

there `environ['HTTP_COOKIE']` is a Unicode string (Python 2), but
(oddly) `Cookie:BaseCookie`'s `load` method checks for `type("")` rather
than `basestring`

presumably this is a bug in the latest version of wsgi-intercept:
`environ` data should still be UTF-8-encoded, no?
