### PR TITLE
PID management for twanager server

### DIFF
--- a/tiddlyweb/commands/__init__.py
+++ b/tiddlyweb/commands/__init__.py
@@ -47,7 +47,7 @@ def init(config):
     @make_command()
     def server(args):
         """Start the server using config settings. Provide <host name or IP number> <port> to override."""
-        pid = args[0] == '--pid'
+        pid = len(args) and args[0] == '--pid'
         if pid:
             import os
             args.pop(0)


### PR DESCRIPTION
I frequently find myself writing scripts like this:

```
#!/usr/bin/env sh

set -e

if [ -f "server.pid" ]; then
    kill `cat server.pid` || true
    rm server.pid
fi

if [ "$1" = "-q" ]; then
    exit 0
fi

twanager server &
echo "$!" > server.pid
```

it seemed like `twanager server` might as well (optionally) take care of this itself
