### PR TITLE
Add application/x-tiddler-dictionary to the list of pseudo binary types

### DIFF
--- a/tiddlyweb/util.py
+++ b/tiddlyweb/util.py
@@ -115,7 +115,8 @@ def pseudo_binary(content_type):
             or content_type.endswith('+xml')
             or content_type.endswith('+json')
             or content_type == 'application/javascript'
-            or content_type == 'application/json')
+            or content_type == 'application/json'
+            or content_type == 'application/x-tiddler-dictionary')
 
 
 def read_utf8_file(filename):


### PR DESCRIPTION
Without this change tiddler with content type `application/x-tiddler-dictionary` gets corrupted.
It seems that it is not enough to make TW5 work with TiddlyWeb since there are some other issues I experience (maybe not related) - eg. custom palette which has this content type do not load automatically unless I open that tiddler manually.

Am I missing something?
