### PR TITLE
Update yield generate tests to use pytest_generate_tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ META = {
         'httpexceptor>=1.3.0',
         'selector>=0.10.0',
         'simplejson',
-        'html5lib',
+        'html5lib<0.99999999',
         'python-mimeparse>0.1.3'
     ],
     'extras_require': {

--- a/test/http_runner.py
+++ b/test/http_runner.py
@@ -15,10 +15,20 @@ http = get_http()
 __all__ = ('http_test', 'test_assert_response', 'test_the_TESTS')
 
 
-def http_test(test_data, base):
-    global tests, store, base_url
-    base_url = base
-    tests = test_data
+EMPTY_TEST = {
+        'name': '',
+        'desc': '',
+        'method': 'GET',
+        'url': '',
+        'status': '200',
+        'request_headers': {},
+        'response_headers': {},
+        'expected': [],
+        'data': '',
+        }
+
+
+def http_test():
     initialize_app()
     reset_textstore()
     store = _teststore()
@@ -29,6 +39,18 @@ def http_test(test_data, base):
     user = User('cdent')
     user.set_password('cowpig')
     store.put(user)
+
+
+def generate_tests(tests, base_url):
+    data_list = []
+    ids = []
+    for test_data in tests:
+        test = dict(EMPTY_TEST)
+        test.update(test_data)
+        full_url = base_url + test['url']
+        data_list.append((test, full_url))
+        ids.append(test['name'])
+    return data_list, ids
 
 
 def test_assert_response():
@@ -49,31 +71,7 @@ def test_assert_response():
     assert_response(response, content, status, headers, expected)
 
 
-EMPTY_TEST = {
-        'name': '',
-        'desc': '',
-        'method': 'GET',
-        'url': '',
-        'status': '200',
-        'request_headers': {},
-        'response_headers': {},
-        'expected': [],
-        'data': '',
-        }
-
-
-def test_the_TESTS():
-    """
-    Run the entire TEST.
-    """
-    for test_data in tests:
-        test = dict(EMPTY_TEST)
-        test.update(test_data)
-        yield test['name'], _run_test, test
-
-
-def _run_test(test):
-    full_url = base_url + test['url']
+def test_generic(test, full_url):
     if test['method'] == 'GET' or test['method'] == 'DELETE':
         response, content = http.requestU(full_url,
                 method=test['method'],

--- a/test/test_urlmap.py
+++ b/test/test_urlmap.py
@@ -5,7 +5,7 @@ import string
 import simplejson
 
 # test_the_TESTS required to make tests go
-from .http_runner import http_test, test_the_TESTS
+from .http_runner import generate_tests, test_generic, http_test
 
 
 def fixup(pattern):
@@ -97,8 +97,15 @@ def figure_tests(app):
 
 
 def setup_module(module):
+    http_test()
+
+
+def pytest_generate_tests(metafunc):
     tests = do_run()
-    http_test(tests, 'http://our_test_domain:8001')
+    if metafunc.function == test_generic:
+        base_url = 'http://our_test_domain:8001'
+        data_list, ids = generate_tests(tests, base_url)
+        metafunc.parametrize("test, full_url", argvalues=data_list, ids=ids)
 
 
 def do_run():

--- a/test/test_web_http_api.py
+++ b/test/test_web_http_api.py
@@ -4,12 +4,19 @@ expand, explain, etc.
 """
 
 import yaml
-
 # test_* required to make tests discoverable
-from .http_runner import http_test, test_the_TESTS, test_assert_response
+from .http_runner import generate_tests, test_generic, http_test
 
 
 def setup_module(module):
-    with open('test/httptest.yaml') as yaml_file:
-        tests = yaml.load(yaml_file)
-        http_test(tests, 'http://our_test_domain:8001')
+    http_test()
+
+
+def pytest_generate_tests(metafunc):
+    if metafunc.function == test_generic:
+        data_file = 'test/httptest.yaml'
+        base_url = 'http://our_test_domain:8001'
+        with open(data_file) as yaml_file:
+            tests = yaml.load(yaml_file)
+        data_list, ids = generate_tests(tests, base_url)
+        metafunc.parametrize("test, full_url", argvalues=data_list, ids=ids)


### PR DESCRIPTION
pytest has deprecated yield style generated tests and emits warnings
when they are used. These can be replaced by using the
pytest_generate_tests method which is one of several mystical methods
that are provided in modern pytest. See this thread (it starts before
october):

```
https://mail.python.org/pipermail/pytest-dev/2016-October/003905.html
```

This process does essentially the same thing but it is done in a way
that is more correct with how pytest does test collection and per
test fixture handling.

These changes allowed (or revealed) some cleanups to the imports and
removal of some globals.

/cc @FND
